### PR TITLE
fix: make cwd a required positional parameter in spawn_teammate

### DIFF
--- a/src/claude_teams/server.py
+++ b/src/claude_teams/server.py
@@ -415,10 +415,10 @@ def spawn_teammate_tool(
     team_name: str,
     name: str,
     prompt: str,
+    cwd: str,
     ctx: Context,
     model: str = "sonnet",
     subagent_type: str = "general-purpose",
-    cwd: str = "",
     plan_mode_required: bool = False,
     backend_type: Literal["claude", "opencode"] = "claude",
 ) -> dict:


### PR DESCRIPTION
Move cwd before ctx and remove its empty-string default, since the validation already rejects non-absolute paths.